### PR TITLE
Meshy AI API 프롬포트 수정 및 OpenAI의 chatGPT를 활용한 이미지 분석 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 │               │   ├── KakaoLoginController
 │               │   ├── KakaoPayController
 │               │   ├── MessageController
+│               │   ├── OpenAIController
 │               │   ├── PrinterController
 │               │   └── UserController
 │               ├── dto
@@ -102,6 +103,7 @@
 │                   ├── KakaoPayService
 │                   ├── MeshyApiService
 │                   ├── MessageService
+│                   ├── OpenAIService
 │                   ├── PrinterService
 │                   └── UserService
 └── test

--- a/src/main/java/com/hyunn/capstone/controller/OpenAIController.java
+++ b/src/main/java/com/hyunn/capstone/controller/OpenAIController.java
@@ -28,7 +28,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/image/openai")
-public class openAIController {
+public class OpenAIController {
 
   private final OpenAIService openAIService;
 

--- a/src/main/java/com/hyunn/capstone/controller/openAIController.java
+++ b/src/main/java/com/hyunn/capstone/controller/openAIController.java
@@ -1,0 +1,79 @@
+package com.hyunn.capstone.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.hyunn.capstone.dto.response.ApiStandardResponse;
+import com.hyunn.capstone.service.OpenAIService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "3D image api (openAI)", description = "3D 이미지 API by openAI")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/image/openai")
+public class openAIController {
+
+  private final OpenAIService openAIService;
+
+  @Operation(summary = "3D 이미지 반환", description = "이미지를 openAI API를 통해 3D 이미지 프롬포트를 반환한다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "키워드 반환"),
+      @ApiResponse(responseCode = "400",
+          description = "1. 파라미터가 부족합니다. \t\n"
+              + "2. 올바르지 않은 파라미터 값입니다. \t\n"
+              + "3. 올바르지 않은 JSON 형식입니다. \t\n"
+              + "4. 지원하지 않는 형식의 데이터 요청입니다. \t\n"
+              + "5. 멀티 파트가 부족합니다. \t\n"
+              + "6. 파일의 용량이 너무 큽니다.",
+          content = @Content(mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = "{ \"code\": \"01\", \"msg\": \"fail\","
+                  + " \"data\": {\"status\": \"INVALID_PARAMETER\", "
+                  + "\"msg\":\"올바르지 않은 파라미터 값입니다.\"} }"))),
+      @ApiResponse(responseCode = "403",
+          description = "API KEY가 올바르지 않습니다.",
+          content = @Content(mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = "{ \"code\": \"12\", \"msg\": \"fail\","
+                  + " \"data\": {\"status\": \"AUTHENTICATION_EXCEPTION\", "
+                  + "\"msg\":\"API KEY가 올바르지 않습니다.\"} }"))),
+      @ApiResponse(responseCode = "404",
+          description = "1. Api 응답이 올바르지 않습니다. \t\n"
+              + "2. S3 업로드가 실패했습니다. \t\n"
+              + "3. 이미지 파일만 업로드 가능합니다.",
+          content = @Content(mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class),
+              examples = @ExampleObject(value = "{ \"code\": \"10\", \"msg\": \"fail\","
+                  + " \"data\": {\"status\": \"API_NOT_FOUND_EXCEPTION\", "
+                  + "\"msg\":\"Api 응답이 올바르지 않습니다.\"} }")))})
+  @Parameter(name = "x-api-key", description = "x-api-key", schema = @Schema(type = "string"),
+      in = ParameterIn.HEADER, example = "testApiKey2024")
+  @PostMapping(value = "/image_to_text", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<ApiStandardResponse<Map<String, String>>> imageToText(
+      @RequestHeader(value = "x-api-key", required = false) String apiKey,
+      @Parameter(
+          description = "multipart/form-data 형식의 10MB 이하 이미지 파일을 받습니다.",
+          content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)
+      )
+      @RequestPart("file") MultipartFile file) throws JsonProcessingException {
+    Map<String, String> message = openAIService.imageToText(apiKey, file);
+    return ResponseEntity.ok(ApiStandardResponse.success(message));
+  }
+}

--- a/src/main/java/com/hyunn/capstone/controller/openAIController.java
+++ b/src/main/java/com/hyunn/capstone/controller/openAIController.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-@Tag(name = "3D image api (openAI)", description = "3D 이미지 API by openAI")
+@Tag(name = "3D image api (논문용)", description = "3D 이미지 API by openAI")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/image/openai")

--- a/src/main/java/com/hyunn/capstone/service/MeshyApiService.java
+++ b/src/main/java/com/hyunn/capstone/service/MeshyApiService.java
@@ -69,7 +69,8 @@ public class MeshyApiService {
     // 요청 바디를 구성합니다.
     Map<String, Object> requestBody = new HashMap<>();
     requestBody.put("mode", "preview");
-    String prompt = "3D model of " + "(" + gender + ") " + keyWord + ", " + emotion + ", " + "detailed, cartoon style, only face";
+    String prompt = "3D model of " + "(" + gender + ") " + keyWord + ", " + emotion + ", "
+        + "detailed, cartoon style, only face";
     requestBody.put("prompt", prompt);
 
     String artStyle = "cartoon";

--- a/src/main/java/com/hyunn/capstone/service/MeshyApiService.java
+++ b/src/main/java/com/hyunn/capstone/service/MeshyApiService.java
@@ -69,13 +69,13 @@ public class MeshyApiService {
     // 요청 바디를 구성합니다.
     Map<String, Object> requestBody = new HashMap<>();
     requestBody.put("mode", "preview");
-    requestBody.put("prompt", keyWord);
+    String prompt = "3D model of " + "(" + gender + ") " + keyWord + ", " + emotion + ", " + "detailed, cartoon style, only face";
+    requestBody.put("prompt", prompt);
 
-    String artStyle = "realistic";
+    String artStyle = "cartoon";
     requestBody.put("art_style", artStyle);
 
-    // 프롬포트는 추가적인 수정이 필요함.
-    String negativePrompt = gender + ", " + emotion + ", toy";
+    String negativePrompt = "low quality, ugly";
     requestBody.put("negative_prompt", negativePrompt);
 
     // HttpEntity를 생성합니다.

--- a/src/main/java/com/hyunn/capstone/service/MeshyApiService.java
+++ b/src/main/java/com/hyunn/capstone/service/MeshyApiService.java
@@ -76,7 +76,7 @@ public class MeshyApiService {
     String artStyle = "cartoon";
     requestBody.put("art_style", artStyle);
 
-    String negativePrompt = "low quality, ugly";
+    String negativePrompt = "ugly, low quality";
     requestBody.put("negative_prompt", negativePrompt);
 
     // HttpEntity를 생성합니다.
@@ -173,7 +173,7 @@ public class MeshyApiService {
 
     String obj = null;
     if (status.equals("SUCCEEDED")) {
-      obj = jsonObject.getAsJsonObject("model_urls").get("obj").getAsString();
+      obj = jsonObject.getAsJsonObject("model_urls").get("mtl").getAsString();
     }
     return obj;
   }

--- a/src/main/java/com/hyunn/capstone/service/OpenAIService.java
+++ b/src/main/java/com/hyunn/capstone/service/OpenAIService.java
@@ -1,0 +1,116 @@
+package com.hyunn.capstone.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hyunn.capstone.exception.ApiKeyNotValidException;
+import com.hyunn.capstone.exception.ApiNotFoundException;
+import com.hyunn.capstone.exception.FileNotAllowedException;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class OpenAIService {
+
+  @Value("${spring.security.x-api-key}")
+  private String xApiKey;
+
+  @Value("${openai.api-key}")
+  private String openAIKey;
+
+  private final ImageService imageService;
+
+  /**
+   * img_to_text (chat gpt 4o)
+   */
+  @Transactional
+  public Map<String, String> imageToText(String apiKey, MultipartFile multipartFile)
+      throws JsonProcessingException {
+    // API KEY 유효성 검사
+    if (apiKey == null || !apiKey.equals(xApiKey)) {
+      throw new ApiKeyNotValidException("API KEY가 올바르지 않습니다.");
+    }
+
+    // 이미지 파일인지 확인
+    if (!multipartFile.isEmpty() && !multipartFile.getContentType().startsWith("image")) {
+      throw new FileNotAllowedException("이미지 파일만 업로드 가능합니다.");
+    }
+
+    // 이미지는 jpg로 변환 후 S3에 저장
+    String imageUrl = imageService.uploadFile(multipartFile);
+
+    String apiUri = "https://api.openai.com/v1/chat/completions";
+    RestTemplate restTemplate = new RestTemplate();
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.set("Authorization", "Bearer " + openAIKey);
+
+    // 요청 메시지 구성
+    Map<String, Object> messageContentText = new HashMap<>();
+    messageContentText.put("type", "text");
+    messageContentText.put("text",
+        "당신은 제시된 이미지를 text-3d 모델링으로 변환해주는 생성형 AI의 프롬프트를 만드는 프롬프트 전문가입니다. 입력한 이미지를 3D 모델링으로 변환할 수 있도록 구체적으로 묘사해 주세요. 그림 전체를 묘사할 필요 없이, 그림에서 가장 핵심적인 부분에 대해 자세히 묘사하면 됩니다. 영문으로 작성해 주시고, 그림의 핵심적인 부분을 구체적으로 묘사해주세요.");
+
+    Map<String, Object> messageContentImage = new HashMap<>();
+    messageContentImage.put("type", "image_url");
+    messageContentImage.put("image_url", Map.of("url", imageUrl));
+
+    Map<String, Object> message = new HashMap<>();
+    message.put("role", "user");
+    message.put("content", new Object[]{messageContentText, messageContentImage});
+
+    Map<String, Object> requestBody = new HashMap<>();
+    requestBody.put("model", "gpt-4-turbo");
+    requestBody.put("messages", new Object[]{message});
+
+    // HttpEntity를 생성합니다.
+    HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(requestBody, headers);
+
+    // API 호출을 수행합니다.
+    ResponseEntity<String> response = restTemplate.exchange(
+        apiUri,
+        HttpMethod.POST,
+        requestEntity,
+        String.class
+    );
+
+    // API 응답을 처리합니다.
+    if (response.getStatusCode().is2xxSuccessful()) {
+      // 성공적으로 API를 호출한 경우의 처리
+      System.out.println("API 호출 성공: " + response.getBody());
+    } else {
+      // API 호출이 실패한 경우의 처리
+      System.out.println("API 호출 실패: " + response.getStatusCode());
+      throw new ApiNotFoundException("API 호출에 문제가 생겼습니다.");
+    }
+
+    // JSON 파싱
+    String responseBody = response.getBody();
+    if (responseBody == null || responseBody.isEmpty()) {
+      throw new ApiNotFoundException("API 응답이 비어 있습니다.");
+    }
+
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode responseJson = mapper.readTree(response.getBody());
+    String content = responseJson.get("choices").get(0).get("message").get("content").asText();
+
+    // 원하는 데이터 형식으로 변환
+    Map<String, String> resultData = new HashMap<>();
+    resultData.put("message", content);
+    resultData.put("image", imageUrl);
+
+    return resultData;
+  }
+}


### PR DESCRIPTION
### 🔖작업내용

1. Meshy AI API 프롬포트 수정 
2. mtl로 3d obj 형식 변경
3. OpenAI의 chatGPT를 활용한 이미지 분석 추가 (논문을 위한)

### 📨관련 이슈

Resolved: #9, #13, #23
